### PR TITLE
Adding Code editors to exceptions

### DIFF
--- a/windows_shortcuts.json
+++ b/windows_shortcuts.json
@@ -18,7 +18,10 @@
               "type": "frontmost_application_unless",
               "bundle_identifiers": [
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -46,7 +49,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -71,7 +77,10 @@
               "type": "frontmost_application_unless",
               "bundle_identifiers": [
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -99,7 +108,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -127,7 +139,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -155,7 +170,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -183,7 +201,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -211,7 +232,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -239,7 +263,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -267,7 +294,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -295,7 +325,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -323,7 +356,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -351,7 +387,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -379,7 +418,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -407,7 +449,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -435,7 +480,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -466,7 +514,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -494,7 +545,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -539,7 +593,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -567,7 +624,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -595,7 +655,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -648,7 +711,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -676,7 +742,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -766,7 +835,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -794,7 +866,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -822,7 +897,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -850,7 +928,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -878,7 +959,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -907,7 +991,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -935,7 +1022,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -963,7 +1053,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1016,7 +1109,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1044,7 +1140,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1072,7 +1171,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1100,7 +1202,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1108,9 +1213,6 @@
         }
       ]
     },
-
-
-
     {
       "description": "/ (Ctrl)",
       "manipulators": [
@@ -1128,7 +1230,10 @@
               "type": "frontmost_application_unless",
               "bundle_identifiers": [
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1136,9 +1241,6 @@
         }
       ]
     },
-
-
-
     {
       "description": "F1",
       "manipulators": [
@@ -1159,7 +1261,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1187,7 +1292,10 @@
                 "^com\\.googlecode\\.iterm2$",
                 "^co\\.zeit\\.hyper$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],
@@ -1212,7 +1320,10 @@
               "type": "frontmost_application_unless",
               "bundle_identifiers": [
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                "^com\\.microsoft\\.rdc\\.macos$"
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.VSCode$",
+                "^com\\.jetbrains\\.intellij\\.ce$",
+                "^com\\.sublimetext\\.3$"
               ]
             }
           ],


### PR DESCRIPTION
Because they have their own keybinding files (e.g. in vscode keybindings.json)

So if someone works with vscode they are better served by excluding the modifications by this project and using a plugin like this instead: https://marketplace.visualstudio.com/items?itemName=smcpeak.default-keys-windows or if they use intellij IDEA then https://marketplace.visualstudio.com/items?itemName=zpeterg.intellij-idea-keybindings-mac-to-pc
