### PR TITLE
Add PhpStorm to the exclude list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Generally Excepted Applications:
 * IDEs
   * JetBrains IntelliJ IDEA CE
   * JetBrains PyCharm
+  * JetBrains PhpStorm
   * Sublime Text
   * Microsoft VSCode
 * Remote Desktops

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Generally Excepted Applications:
 - [@Ivanca](https://github.com/Ivanca) for adding IDEs to list of exceptions
 - [@from-nibly](https://github.com/from-nibly) for adding VMware Fusion to list of exceptions
 - [@andormarkus](https://github.com/andormarkus) for adding JetBrains PyCharm to list of exceptions
+- [@amateescu](https://github.com/amateescu) for adding JetBrains PhpStorm to list of exceptions
 
 ## Links
 - Karabiner-Elements [(Homepage)](https://pqrs.org/osx/karabiner/) [(GitHub)](https://github.com/tekezo/Karabiner-Elements)

--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -15,6 +15,7 @@
     '^com\\.microsoft\\.VSCode$',
     '^com\\.jetbrains\\.intellij\\.ce$',
     '^com\\.jetbrains\\.pycharm$',
+    '^com\\.jetbrains\\.PhpStorm$',
     '^com\\.sublimetext\\.3$',
   ],
 


### PR DESCRIPTION
So it's own keymap feature works correctly.