### PR TITLE
Feature: Add emacs to IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Generally Excepted Applications:
   * JetBrains PhpStorm
   * Sublime Text
   * Microsoft VSCode
+  * Emacs (GUI)
 * Remote Desktops
   * Microsoft Remote Desktop Connection
   * Citrix XenAppViewer
@@ -119,6 +120,7 @@ Generally Excepted Applications:
 - [@from-nibly](https://github.com/from-nibly) for adding VMware Fusion to list of exceptions
 - [@andormarkus](https://github.com/andormarkus) for adding JetBrains PyCharm to list of exceptions
 - [@amateescu](https://github.com/amateescu) for adding JetBrains PhpStorm to list of exceptions
+- [@vidurb](https://github.com/vidurb) for adding Emacs to list of exceptions
 
 ## Links
 - Karabiner-Elements [(Homepage)](https://pqrs.org/osx/karabiner/) [(GitHub)](https://github.com/tekezo/Karabiner-Elements)

--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -17,6 +17,7 @@
     '^com\\.jetbrains\\.pycharm$',
     '^com\\.jetbrains\\.PhpStorm$',
     '^com\\.sublimetext\\.3$',
+    '^org\\.gnu\\.emacs$',
   ],
 
   // bundle identifiers for remote desktop applications


### PR DESCRIPTION
Pretty self-explanatory - I just added the bundle ID for Emacs to the 'IDEs' array after I noticed some shortcuts going awry while using it.