### PR TITLE
Add JetBrains Rider to IDE exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Generally Excepted Applications:
   * JetBrains IntelliJ IDEA CE
   * JetBrains PyCharm
   * JetBrains PhpStorm
+  * JetBrains Rider
   * Sublime Text
   * Microsoft VSCode
 * Remote Desktops

--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -16,6 +16,7 @@
     '^com\\.jetbrains\\.intellij\\.ce$',
     '^com\\.jetbrains\\.pycharm$',
     '^com\\.jetbrains\\.PhpStorm$',
+    '^com\\.jetbrains\\.rider$',
     '^com\\.sublimetext\\.3$',
   ],
 


### PR DESCRIPTION
As with similar JetBrains IDEs on the list, this allows the IDE keymaps to work correctly for JetBrains Rider.