### PR TITLE
Change CTRL+C to LEFT_CTRL+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Generally Excepted Applications:
 |-|-|-|-|-|
 | A | Ctrl | A | Command |  |
 | B | Ctrl | B | Command |  |
-| C | Ctrl | C | Command |  |
+| C | Left Ctrl | C | Command |  |
 | C | Ctrl+Shift | C | Command | Only applies to Terminal Emulators. |
 | F | Ctrl | F | Command |  |
 | I | Ctrl | I | Command |  |

--- a/jsonnet/windows_shortcuts.jsonnet
+++ b/jsonnet/windows_shortcuts.jsonnet
@@ -109,7 +109,7 @@ local k = import 'lib/karabiner.libsonnet';
            k.outputKey('b', ['command']),
            k.condition('unless', bundle.standard)),
     k.rule('C (Ctrl)',
-           k.input('c', ['control']),
+           k.input('c', ['left_control']),
            k.outputKey('c', ['command']),
            k.condition('unless', bundle.standard)),
     k.rule('C (Ctrl+Shift) [Only Terminal Emulators]',


### PR DESCRIPTION
In support of Issue #51, let's try making that key bind only for left control, leaving right control available to use with the standard CTRL+C combination in a terminal.