### PR TITLE
Show diff of jsonnetfmt output

### DIFF
--- a/.github/jsonnet_format_check.sh
+++ b/.github/jsonnet_format_check.sh
@@ -10,8 +10,13 @@ cd "${1:-.}"
 
 # test jsonnet and libsonnet files
 for file in ./**/*.{j,lib}sonnet; do
+    error_this_file=0
     printf 'jsonnetfmt --test -- "%s"\n' "${file}"
-    jsonnetfmt --test -- "${file}" || error=1
+    jsonnetfmt --test -- "${file}" || { error=1; error_this_file=1; }
+    if [[ $error_this_file -eq 1 ]]; then
+        jsonnetfmt -i -- "${file}"
+        git --no-pager diff --unified=0 --no-ext-diff -- "${file}" | tail -n +5
+    fi
 done
 
 exit ${error}


### PR DESCRIPTION
Alters the `jsonnet_format_check.sh` script so that if the `jsonnetfmt --test ...` command fails, a short diff will be output of what exactly the program picked up on.