### PR TITLE
WinKey to open Spotlight & more JetBrains tools as exceptions

### DIFF
--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -17,14 +17,8 @@
   ides: [
     // GNU Emacs (GUI)
     '^org\\.gnu\\.emacs$',
-    // JetBrains IntelliJ
-    '^com\\.jetbrains\\.intellij\\.ce$',
-    // JetBrains PhpStorm
-    '^com\\.jetbrains\\.PhpStorm$',
-    // JetBrains PyCharm
-    '^com\\.jetbrains\\.pycharm$',
-    // JetBrains Rider
-    '^com\\.jetbrains\\.rider$',
+    // JetBrains tools
+    '^com\\.jetbrains',
     // Microsoft VSCode
     '^com\\.microsoft\\.VSCode$',
     // Sublime Text

--- a/jsonnet/lib/karabiner.libsonnet
+++ b/jsonnet/lib/karabiner.libsonnet
@@ -21,9 +21,10 @@
     manipulators: [
       {
         from: input,
-        [output.to_type]: [
-          output.output,
-        ],
+      } + {
+        [o.to_type]: [o.output]
+        for o in if std.isArray(output) then output else [output] + []
+      } + {
         [if condition != null then 'conditions']: [
           condition,
         ],
@@ -60,10 +61,10 @@
   //
   // output_type (string, optional)
   //   type of 'to' object; should normally be left alone
-  outputKey(key, modifiers=null, output_type='to'):: {
+  outputKey(key, modifiers=null, output_type='to', key_code='key_code',):: {
     to_type: output_type,
     output: {
-      key_code: key,
+      [key_code]: key,
       [if modifiers != null then 'modifiers']: modifiers,
     },
   },

--- a/jsonnet/windows_shortcuts.jsonnet
+++ b/jsonnet/windows_shortcuts.jsonnet
@@ -96,9 +96,10 @@ local k = import 'lib/karabiner.libsonnet';
            k.outputKey('return_or_enter', ['command', 'shift']),
            k.condition('unless', bundle.standard)),
     // Modifier Keys
-    k.rule('Win',
-           k.input('command', key_is_modifier=true),
-           k.outputKey('launchpad', output_type='to_if_alone')),
+    k.rule('Win [Open Spotlight]',
+           k.input('left_command', key_is_modifier=true),
+           [k.outputKey('left_command', output_type='to'),
+           k.outputKey('spotlight', output_type='to_if_alone', key_code='apple_vendor_keyboard_key_code')]),
     // Alphanumeric Keys
     k.rule('A (Ctrl)',
            k.input('a', ['control']),


### PR DESCRIPTION
- WinKey to open Spotlight (it's more versatile than Launchpad) - the rule requires both `to` and `to_if_alone` outputs to work properly
- more JetBrains tools in exceptions - the bundle pattern got simplified