### PR TITLE
terminal-exception: terminal emulator Kitty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Generally Excepted Applications:
   * Alacritty
   * Hyper
   * iTerm2
+  * Kitty
   * Terminal
   * WezTerm
 

--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -23,6 +23,8 @@
     '^com\\.microsoft\\.VSCode$',
     // Sublime Text
     '^com\\.sublimetext\\.3$',
+    // Kitty
+    '^net\\.kovidgoyal\\.kitty$',
   ],
 
   // bundle identifiers for remote desktop applications


### PR DESCRIPTION
Add the terminal emulator Kitty to the exception list.

More information on Kitty may be found at:
  - https://github.com/kovidgoyal/kitty/
  - https://sw.kovidgoyal.net/kitty/