### PR TITLE
Fix/filepath condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ default: check format
 
 check:
 	echo "checking..."
-	.github/render_json.sh ./jsonnet /dev/null
+	.github/scripts/render_json.sh ./jsonnet /dev/null
 
 format:
 	echo "formatting..."
-	.github/jsonnet_fmt.sh
+	.github/scripts/jsonnet_fmt.sh
 
 render:
 	echo "rendering..."
-	.github/render_json.sh ./jsonnet ./json
+	.github/scripts/render_json.sh ./jsonnet ./json

--- a/jsonnet/lib/karabiner.libsonnet
+++ b/jsonnet/lib/karabiner.libsonnet
@@ -96,9 +96,7 @@
   condition(type, bundles, file_paths=null):: {
     type: 'frontmost_application_' + type,
     bundle_identifiers: bundles,
-    [if file_paths != null then 'file_paths']: [
-      file_paths,
-    ],
+    [if file_paths != null then 'file_paths']: file_paths,
   },
 
   // runDockedApp


### PR DESCRIPTION
Relates to https://github.com/rux616/karabiner-windows-mode/issues/73

The `file_paths` node is expected to be a single level array.

Current json is invalid:
```
"conditions": [
                  {
                    ...
                     "file_paths": [
                        [
                           "Chrome Remote Desktop\\.app"
                        ]
                     ],
                     "type": "frontmost_application_unless"
                  }
               ],
```