### PR TITLE
Add bundle identifier for Emacs (with a capital E)

### DIFF
--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -17,6 +17,7 @@
   ides: [
     // GNU Emacs (GUI)
     '^org\\.gnu\\.emacs$',
+    '^org\\.gnu\\.Emacs$',
     // JetBrains tools
     '^com\\.jetbrains',
     // Microsoft VSCode


### PR DESCRIPTION
For my install of emacs, the identifier is `org.gnu.Emacs`.  This change allows the terminal rules to be respected on emacs.

I tried adding the case-insensitive flag to the regex but that didn't work. 

Please let me know if I can improve this PR!