### PR TITLE
Exclusion for Beyond Compare

### DIFF
--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -28,6 +28,8 @@
     '^com\\.sublimetext\\.3$',
     // Kitty
     '^net\\.kovidgoyal\\.kitty$',
+    // Beyond Compare 4 & 5
+    '^com\\.ScooterSoftware',
   ],
 
   // bundle identifiers for remote desktop applications


### PR DESCRIPTION
Add app exclusion for Beyond Compare (versions 4 and 5).