### PR TITLE
Added Screenshot Area Capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore the standard test json
 test.json
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 test.json
 
 .DS_Store
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ List of Web Browsers:
 - [@simonLeary42](https://github.com/simonLeary42) for adding VSCodium bundle, adding "H (Ctrl) [Web Browsers Only]", and adding "F5 [Only Chrome]", renaming some rules, fixing priority of home/end rules, and refactoring
 - [@elijaholmos](https://github.com/elijaholmos) for adding in the new Alacritty bundle ID
 - [@jelmansouri](https://github.com/jelmansouri) for adding in Ghostty's bundle ID
+- [@dariuszsmolarek](https://github.com/dariuszsmolarek) for adding Screenshot Area (Win+Shift+S)
 
 ([TOC](#table-of-contents))
 

--- a/json/windows_shortcuts.json
+++ b/json/windows_shortcuts.json
@@ -2654,35 +2654,6 @@
          ]
       },
       {
-         "description": "S (Win+Shift) [Screenshot Area] [Always]",
-         "manipulators": [
-            {
-               "from": {
-                  "key_code": "s",
-                  "modifiers": {
-                     "mandatory": [
-                        "command",
-                        "shift"
-                     ],
-                     "optional": [
-                        "any"
-                     ]
-                  }
-               },
-               "to": [
-                  {
-                     "key_code": "4",
-                     "modifiers": [
-                        "command",
-                        "shift"
-                     ]
-                  }
-               ],
-               "type": "basic"
-            }
-         ]
-      },
-      {
          "description": "Insert (Ctrl) [+Terminal Emulators]",
          "manipulators": [
             {
@@ -3160,3 +3131,4 @@
    ],
    "title": "Windows Shortcuts"
 }
+

--- a/json/windows_shortcuts.json
+++ b/json/windows_shortcuts.json
@@ -2654,6 +2654,35 @@
          ]
       },
       {
+         "description": "S (Win+Shift) [Screenshot Area] [Always]",
+         "manipulators": [
+            {
+               "from": {
+                  "key_code": "s",
+                  "modifiers": {
+                     "mandatory": [
+                        "command",
+                        "shift"
+                     ],
+                     "optional": [
+                        "any"
+                     ]
+                  }
+               },
+               "to": [
+                  {
+                     "key_code": "4",
+                     "modifiers": [
+                        "command",
+                        "shift"
+                     ]
+                  }
+               ],
+               "type": "basic"
+            }
+         ]
+      },
+      {
          "description": "Insert (Ctrl) [+Terminal Emulators]",
          "manipulators": [
             {

--- a/json/windows_shortcuts.json
+++ b/json/windows_shortcuts.json
@@ -3131,4 +3131,3 @@
    ],
    "title": "Windows Shortcuts"
 }
-

--- a/jsonnet/windows_shortcuts.jsonnet
+++ b/jsonnet/windows_shortcuts.jsonnet
@@ -239,6 +239,9 @@ local unless_remoteDesktop_hypervisor = k.condition(
     k.rule('L (Alt+Ctrl) [Sleep] [Always]',
            k.input('l', ['control', 'option']),
            k.outputKey('power', ['control', 'shift'])),
+    k.rule('S (Win+Shift) [Screenshot Area] [Always]',
+           k.input('s', ['command', 'shift']),
+           k.outputKey('4', ['command', 'shift'])),
     ////////////////////////////////////////////////////////////////////////////////////////////////
     k.rule('Insert (Ctrl) [+Terminal Emulators]',
            k.input('insert', ['control']),


### PR DESCRIPTION
Added a Win+Shift+S shortcut, an equivalent of Command+Shift+4 for screenshotting a desired area of the screen. Also, modified the .gitignore file to exclude MacOS .DS_Store file and IntelliJ IDEA boilerplate files.