### PR TITLE
fix(windows): remove redundant optional modifier

### DIFF
--- a/json/windows_shortcuts.json
+++ b/json/windows_shortcuts.json
@@ -610,9 +610,7 @@
                      "mandatory": [
                         "control"
                      ],
-                     "optional": [
-                        "any"
-                     ]
+                     "optional": []
                   }
                },
                "to": [
@@ -726,9 +724,7 @@
                      "mandatory": [
                         "control"
                      ],
-                     "optional": [
-                        "any"
-                     ]
+                     "optional": []
                   }
                },
                "to": [


### PR DESCRIPTION
- Remove `any` from optional modifiers for `control` keybindings
- Fix unexpected behavior in when mapping `control + command + left` in ghostty (dealt by kitty protocol instead of the os)