### PR TITLE
Add wildcard for JetBrains tools

### DIFF
--- a/jsonnet/lib/bundle.libsonnet
+++ b/jsonnet/lib/bundle.libsonnet
@@ -19,7 +19,7 @@
     '^org\\.gnu\\.emacs$',
     '^org\\.gnu\\.Emacs$',
     // JetBrains tools
-    '^com\\.jetbrains',
+    '^com\\.jetbrains$',
     // Microsoft VSCode
     '^com\\.microsoft\\.VSCode$',
     // VSCodium - Open Source VSCode


### PR DESCRIPTION
Thanks for publishing this config! I ran into one issue with JetBrains IDEs not being recognized. The bundle identifier has `com.jetbrains` as a prefix, for example:

```
com.jetbrains.intellij
```
